### PR TITLE
Parse cast types after duplication

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -301,7 +301,8 @@ AstNode* ast_expr_cast_new(const char* type_name, AstNode* expr)
     e->kind = AST_EXPR_CAST;
     e->type_name = type_name ? sdup(type_name) : NULL;
     e->expr = expr;
-    parse_type_details(type_name, &e->q);
+    /* parse qualifiers and other details from the duplicated type string */
+    parse_type_details(e->type_name, &e->q);
     ast_set_lineno((AstNode*)e);
     return (AstNode*)e;
 }

--- a/c.y
+++ b/c.y
@@ -1559,8 +1559,9 @@ unary_expression
         strcat(t, $3);
         if($4) strcat(t, $4);
       }
-      $$ = ast_expr_cast_new(t ? t : $3, $6);
-      free(t); free($2); free($3); free($4);
+      AstNode* cast = ast_expr_cast_new(t ? t : $3, $6);
+      free($2); free($3); free($4); free(t);
+      $$ = cast;
     }
   ;
 


### PR DESCRIPTION
## Summary
- Parse cast expression type details using the duplicated string to avoid use-after-free
- Ensure cast-expression grammar passes constructed type string to AST builder before freeing

## Testing
- `make` *(fails: flex: No such file or directory)*
- `./cparse test/t_cast.c` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9ad677188320bc726c4d0239b952