### PR TITLE
Print function parameter types in ast_print

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -880,8 +880,10 @@ void ast_print(const AstNode* n, int indent)
         for(long i=0;i<f->param_count;i++) {
             const AstParam* p = &f->params[i];
             print_indent(indent+2);
+            char tbuf[256];
+            const char* tname = prettify_type(p->type_name ? p->type_name : "<type>", tbuf, sizeof(tbuf));
             printf("param[%ld]: type=%s name=%s\n", i,
-                   p->type_name ? p->type_name : "<unknown>",
+                   tname,
                    p->name ? p->name : "<anon>");
             if(p->type_name){
                 AstQuals pq; parse_type_details(p->type_name, &pq);
@@ -1201,8 +1203,10 @@ void ast_compile(const AstNode* n, int indent)
         for(long i=0;i<f->param_count;i++) {
             const AstParam* p = &f->params[i];
             print_indent(indent+2);
+            char tbuf[256];
+            const char* tname = prettify_type(p->type_name ? p->type_name : "<type>", tbuf, sizeof(tbuf));
             printf("param[%ld]: type=%s name=%s\n", i,
-                   p->type_name ? p->type_name : "<unknown>",
+                   tname,
                    p->name ? p->name : "<anon>");
             if(p->type_name){
                 AstQuals pq; parse_type_details(p->type_name, &pq);


### PR DESCRIPTION
## Summary
- Improve AST function printing to display each parameter's type and name
- Use `prettify_type` for clearer parameter type strings
- Apply same parameter formatting in `ast_compile`

## Testing
- `make` *(fails: flex: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abbcb11f1c83208f62283300125b26